### PR TITLE
fix: remove reference to .install-filecoin file (#20)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,9 @@ DEPS:=filecoin.h filecoin.pc libfilecoin.a
 all: $(DEPS)
 .PHONY: all
 
-
-$(DEPS): .install-filecoin  ;
-
-.install-filecoin: rust
+$(DEPS):
 	./install-filecoin
-	@touch $@
-
 
 clean:
-	rm -rf $(DEPS) .install-filecoin
+	rm -rf $(DEPS)
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ build tooling will attempt to compile a static library from local Rust sources.
 To opt out of downloading precompiled assets, set `FFI_BUILD_FROM_SOURCE=1`:
 
 ```shell
-rm .install-filecoin \
-    ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 make
+FFI_BUILD_FROM_SOURCE=1 make clean all
 ```
 
 ## License


### PR DESCRIPTION
There is no need to create a `.install-filecoin` file